### PR TITLE
optionally indent each block by the specified number of spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,23 @@ require 'justify'
 # consectetur adipisicing
 # elit sed do eiusmod tempor
 # incididunt ut labore et
-# dolore magna aliqua Ut enim
-# ad minim veniam quis nostrudexercitation ullamco laborisnisi ut aliquip ex ea commodoconsequat
+# dolore magna aliqua. Ut
+# enim ad minim veniam quis
+# nostrud exercitation ullamco
+# laboris nisi ut aliquip
+# ex ea commodo consequat
+
+"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat".justify(20,4)
+
+#     Lorem ipsum dolor sit amet
+#     consectetur adipisicing
+#     elit sed do eiusmod tempor
+#     incididunt ut labore et
+#     dolore magna aliqua. Ut
+#     enim ad minim veniam quis
+#     nostrud exercitation ullamco
+#     laboris nisi ut aliquip
+#     ex ea commodo consequat
 ```
 
 ## Contributing

--- a/lib/justify.rb
+++ b/lib/justify.rb
@@ -1,17 +1,18 @@
 require "justify/version"
 
 class String
-  def justify(len = 80)
+  def justify(len = 80, indent_len = 0)
     unless self.length < len
 
       words = self.gsub("\n", " ").scan(/[\w.-]+/)
       actual_len = 0
-      output = ""
+      output = " " * indent_len
       words.each do |w|
         output += w
         actual_len += w.length
         if actual_len >= len
           output += "\n"
+          output += " " * indent_len
           actual_len = 0
         else
           output += " "
@@ -19,7 +20,7 @@ class String
       end
       return output
     else
-      self
+      " " * indent_len << self
     end
 
   end


### PR DESCRIPTION
Allow user to optionally specify number of spaces they would like prepended to each line, to allow indenting blocks of justified text.

For example, `string.justify(40, 4)` returns

```
    Lorem ipsum dolor sit amet consectetur adipiscing
    elit. Sed ac arcu purus. Nullam tristique facilisis
    auctor. Quisque scelerisque blandit tellus id
    congue. Etiam scelerisque dolor enim at maximus
    nunc aliquet sit amet. Sed faucibus dolor turpis
    non commodo libero gravida at.
```

including leading indentation. If the number of spaces is not specified, the text is not indented. 
