### PR TITLE
keep lines strictly within the specified length

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,11 @@
 require "bundler/gem_tasks"
+
+begin
+  require 'rspec/core/rake_task'
+
+  RSpec::Core::RakeTask.new(:spec)
+
+  task default: :spec
+rescue LoadError
+  puts "no rspec available"
+end

--- a/justify.gemspec
+++ b/justify.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "ipsum"
 end

--- a/lib/justify.rb
+++ b/lib/justify.rb
@@ -8,14 +8,16 @@ class String
       actual_len = 0
       output = ""
       words.each do |w|
-        output += w
-        actual_len += w.length
-        if actual_len >= len
-          output += "\n"
-          actual_len = 0
-        else
-          output += " "
+        if (actual_len > 0)
+          if (actual_len + w.length>len)
+            output += "\n"
+            actual_len = 0
+          else
+            output += " "
+          end
         end
+        output += w
+        actual_len += w.length + 1
       end
       return output
     else

--- a/lib/justify/version.rb
+++ b/lib/justify/version.rb
@@ -1,3 +1,3 @@
 module Justify
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/justify_spec.rb
+++ b/spec/justify_spec.rb
@@ -1,0 +1,36 @@
+﻿require 'rspec'
+require_relative '../lib/justify'
+require 'ipsum'
+
+IPSUM_MAX_WORDLENGTH = 21
+
+describe 'justify' do
+  it 'counts spaces in line length calculation' do
+    expect("a b c d e".justify(3)).to eq "a b\nc d\ne"
+  end 
+  it 'keeps lines strictly within the specified width' do
+    expect("a bsd c dsd esd e e qwe".justify(3)).to eq "a\nbsd\nc\ndsd\nesd\ne e\nqwe"
+  end
+  it 'not adding extra spaces' do
+    expect("a b c d e".justify(22)).to eq "a b c d e"
+    expect("a b c d e".justify(4)).to eq "a b\nc d\ne"
+  end
+  it 'works well with oversized words 1' do
+    expect("qweqwe basd asdc d e".justify(3)).to eq "qweqwe\nbasd\nasdc\nd e"
+  end
+  it 'works well with oversized words 2' do
+    expect("a basd c d e".justify(3)).to eq "a\nbasd\nc d\ne"
+  end
+  it 'works well with oversized words 3' do
+    expect("aasd basd casd dasd".justify(3)).to eq "aasd\nbasd\ncasd\ndasd"
+  end
+  it 'use default width 80' do
+    expect(200.sentences.justify.split("\n").map(&:length)[0..-2]).to all be_between(80-IPSUM_MAX_WORDLENGTH,80)
+  end
+  it 'passes random tests, always keeping length less or equal than defined' do
+    test = 200.sentences
+    (IPSUM_MAX_WORDLENGTH..100).each do |len|      
+      expect(test.justify(len).split("\n").map(&:length)[0..-2]).to all be_between(len-IPSUM_MAX_WORDLENGTH, len)
+    end
+  end
+end


### PR DESCRIPTION
it turned out that it returns lines that are a little longer than the specified length, because they contain an extra word in each line. Here is the fix and tests